### PR TITLE
chore: clarify why we don't create subnet association resources

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -13,3 +13,10 @@ resource "azurerm_nat_gateway_public_ip_association" "this" {
   nat_gateway_id       = azurerm_nat_gateway.this.id
   public_ip_address_id = var.public_ip_address_ids[count.index]
 }
+
+# Don't create "azurerm_subnet_nat_gateway_association" resources in this module.
+# They should be created in the Azure Network module instead:
+# https://registry.terraform.io/modules/equinor/network/azurerm/latest
+#
+# This ensures a standard approach to associating a subnet with a NAT gateway:
+# a subnet is associated with a NAT gateway during subnet creation.


### PR DESCRIPTION
`azurerm_subnet_nat_gateway_association` resources were removed in [v2](https://github.com/equinor/terraform-azurerm-nat/releases/tag/v2.0.0). Add a comment to clarify why, to prevent these resources from being added back in the future.