### PR TITLE
feat!: send flow logs to Log Analytics workspace

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,13 +4,15 @@ Terraform module which creates Azure NAT Gateway resources.
 
 ## Features
 
-- Creates a standard tier NAT gateway in the specified resource group.
+- Creates a StandardV2 tier NAT gateway in the specified resource group.
 - Creates specified Public IP address associations.
 - Creates specified Public IP prefix associations.
+- Flow logs sent to given Log Analytics workspace by default.
 
 ## Prerequisites
 
 - Azure role `Contributor` at the resource group scope.
+- Azure role `Log Analytics Contributor` at the Log Analytics workspace scope.
 
 ## Usage
 
@@ -23,9 +25,10 @@ module "nat" {
   source  = "equinor/nat/azurerm"
   version = "~> 2.1"
 
-  gateway_name        = "example-gateway"
-  resource_group_name = azurerm_resource_group.example.name
-  location            = azurerm_resource_group.example.location
+  gateway_name               = "example-gateway"
+  resource_group_name        = azurerm_resource_group.example.name
+  location                   = azurerm_resource_group.example.location
+  log_analytics_workspace_id = module.log_analytics.workspace_id
 
   public_ip_address_ids = [module.public_ip.address_id]
 }

--- a/main.tf
+++ b/main.tf
@@ -32,7 +32,7 @@ resource "azurerm_monitor_diagnostic_setting" "this" {
   name                           = var.diagnostic_setting_name
   target_resource_id             = azurerm_nat_gateway.this.id
   log_analytics_workspace_id     = var.log_analytics_workspace_id
-  log_analytics_destination_type = null
+  log_analytics_destination_type = "Dedicated"
 
   dynamic "enabled_log" {
     for_each = toset(var.diagnostic_setting_enabled_log_categories)

--- a/main.tf
+++ b/main.tf
@@ -2,7 +2,7 @@ resource "azurerm_nat_gateway" "this" {
   name                = var.gateway_name
   resource_group_name = var.resource_group_name
   location            = var.location
-  sku_name            = "Standard" # Only supported value
+  sku_name            = "StandardV2" # Required to create a diagnostic setting.
 
   tags = var.tags
 }
@@ -27,3 +27,26 @@ resource "azurerm_nat_gateway_public_ip_prefix_association" "this" {
 #
 # This ensures a standard approach to associating a subnet with a NAT gateway:
 # a subnet is associated with a NAT gateway during subnet creation.
+
+resource "azurerm_monitor_diagnostic_setting" "this" {
+  name                           = var.diagnostic_setting_name
+  target_resource_id             = azurerm_nat_gateway.this.id
+  log_analytics_workspace_id     = var.log_analytics_workspace_id
+  log_analytics_destination_type = null
+
+  dynamic "enabled_log" {
+    for_each = toset(var.diagnostic_setting_enabled_log_categories)
+
+    content {
+      category = enabled_log.value
+    }
+  }
+
+  dynamic "enabled_metric" {
+    for_each = toset(var.diagnostic_setting_enabled_metric_categories)
+
+    content {
+      category = enabled_metric.value
+    }
+  }
+}

--- a/variables.tf
+++ b/variables.tf
@@ -13,6 +13,12 @@ variable "location" {
   type        = string
 }
 
+variable "log_analytics_workspace_id" {
+  description = "The ID of the Log Analytics workspace to send diagnostics to."
+  type        = string
+  nullable    = false
+}
+
 variable "public_ip_address_ids" {
   description = "A list of IDs of Public IP addresses to associate with this NAT gateway."
   type        = list(string)
@@ -22,6 +28,27 @@ variable "public_ip_address_ids" {
 variable "public_ip_prefix_ids" {
   description = "A list of IDs of Public IP prefixes to associate with this NAT gateway."
   type        = list(string)
+  default     = []
+}
+
+variable "diagnostic_setting_name" {
+  description = "The name of this diagnostic setting."
+  type        = string
+  nullable    = false
+  default     = "flow-logs"
+}
+
+variable "diagnostic_setting_enabled_log_categories" {
+  description = "A list of log categories to be enabled for this diagnostic setting."
+  type        = list(string)
+  nullable    = false
+  default     = ["NatGatewayFlowLogsV1"]
+}
+
+variable "diagnostic_setting_enabled_metric_categories" {
+  description = "A list of metric categories to be enabled for this diagnostic setting."
+  type        = list(string)
+  nullable    = false
   default     = []
 }
 

--- a/versions.tf
+++ b/versions.tf
@@ -3,8 +3,10 @@ terraform {
 
   required_providers {
     azurerm = {
-      source  = "hashicorp/azurerm"
-      version = ">= 3.0.0"
+      source = "hashicorp/azurerm"
+      # Adds support for the "StandardV2" SKU.
+      # Ref: https://github.com/hashicorp/terraform-provider-azurerm/blob/main/CHANGELOG.md#4670-april-02-2026
+      version = ">= 4.67.0"
     }
   }
 }


### PR DESCRIPTION
The new `StandardV2` SKU supports sending flow logs to Log Analytics using a diagnostic setting.

BREAKING CHANGE: add required variable `log_analytics_workspace_id`.