### PR TITLE
feat!: create Public IP addresses and prefixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Terraform module which creates Azure NAT Gateway resources.
 ## Features
 
 - Creates a StandardV2 tier NAT gateway in the specified resource group.
-- Creates specified Public IP addresses.
+- Creates and associates specified Public IP addresses and prefixes with the NAT gateway.
 - Flow logs sent to given Log Analytics workspace by default.
 
 ## Prerequisites

--- a/README.md
+++ b/README.md
@@ -5,8 +5,7 @@ Terraform module which creates Azure NAT Gateway resources.
 ## Features
 
 - Creates a StandardV2 tier NAT gateway in the specified resource group.
-- Creates specified Public IP address associations.
-- Creates specified Public IP prefix associations.
+- Creates specified Public IP addresses.
 - Flow logs sent to given Log Analytics workspace by default.
 
 ## Prerequisites
@@ -29,8 +28,6 @@ module "nat" {
   resource_group_name        = azurerm_resource_group.example.name
   location                   = azurerm_resource_group.example.location
   log_analytics_workspace_id = module.log_analytics.workspace_id
-
-  public_ip_address_ids = [module.public_ip.address_id]
 }
 
 resource "azurerm_resource_group" "example" {
@@ -45,16 +42,6 @@ module "log_analytics" {
   workspace_name      = "example-workspace"
   resource_group_name = azurerm_resource_group.example.name
   location            = azurerm_resource_group.example.location
-}
-
-module "public_ip" {
-  source  = "equinor/public-ip/azurerm"
-  version = "~> 1.1"
-
-  address_name               = "example-ip"
-  resource_group_name        = azurerm_resource_group.example.name
-  location                   = azurerm_resource_group.example.location
-  log_analytics_workspace_id = module.log_analytics.workspace_id
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Terraform module which creates Azure NAT Gateway resources.
 ## Features
 
 - Creates a StandardV2 tier NAT gateway in the specified resource group.
-- Creates and associates specified Public IP addresses and prefixes with the NAT gateway.
+- Creates and associates a Public IP address the NAT gateway by default.
 - Flow logs sent to given Log Analytics workspace by default.
 
 ## Prerequisites

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Terraform module which creates Azure NAT Gateway resources.
 ## Features
 
 - Creates a StandardV2 tier NAT gateway in the specified resource group.
-- Creates and associates a Public IP address the NAT gateway by default.
+- Creates and associates a Public IP address with the NAT gateway by default.
 - Flow logs sent to given Log Analytics workspace by default.
 
 ## Prerequisites

--- a/examples/basic/main.tf
+++ b/examples/basic/main.tf
@@ -6,11 +6,21 @@ resource "random_id" "example" {
   byte_length = 8
 }
 
+module "log_analytics" {
+  source  = "equinor/log-analytics/azurerm"
+  version = "~> 2.3"
+
+  workspace_name      = "log-${random_id.example.hex}"
+  resource_group_name = var.resource_group_name
+  location            = var.location
+}
+
 module "nat" {
   # source = "github.com/equinor/terraform-azurerm-nat?ref=v0.0.0"
   source = "../.."
 
-  gateway_name        = "ng-${random_id.example.hex}"
-  resource_group_name = var.resource_group_name
-  location            = var.location
+  gateway_name               = "ng-${random_id.example.hex}"
+  resource_group_name        = var.resource_group_name
+  location                   = var.location
+  log_analytics_workspace_id = module.log_analytics.workspace_id
 }

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -13,32 +13,34 @@ resource "random_id" "example" {
 }
 
 module "log_analytics" {
-  source = "github.com/equinor/terraform-azurerm-log-analytics?ref=v2.1.1"
+  source  = "equinor/log-analytics/azurerm"
+  version = "~> 2.3"
 
   workspace_name      = "log-${random_id.example.hex}"
   resource_group_name = var.resource_group_name
   location            = var.location
 }
 
-module "public_ip" {
-  source = "github.com/equinor/terraform-azurerm-public-ip?ref=v0.1.0"
-
-  address_name               = "pip-${random_id.example.hex}"
-  resource_group_name        = var.resource_group_name
-  location                   = var.location
-  log_analytics_workspace_id = module.log_analytics.workspace_id
-
-  tags = local.tags
-}
-
 module "nat" {
   # source = "github.com/equinor/terraform-azurerm-nat?ref=v0.0.0"
   source = "../.."
 
-  gateway_name          = "ng-${random_id.example.hex}"
-  resource_group_name   = var.resource_group_name
-  location              = var.location
-  public_ip_address_ids = [module.public_ip.address_id]
+  gateway_name               = "ng-${random_id.example.hex}"
+  resource_group_name        = var.resource_group_name
+  location                   = var.location
+  log_analytics_workspace_id = module.log_analytics.workspace_id
+
+  public_ip_addresses = {
+    "default" = {
+      name = "nat-pip"
+    }
+  }
+
+  public_ip_prefixes = {
+    "default" = {
+      name = "nat-prefix"
+    }
+  }
 
   tags = local.tags
 }

--- a/main.tf
+++ b/main.tf
@@ -1,24 +1,36 @@
+resource "azurerm_public_ip" "this" {
+  for_each = var.public_ips
+
+  name                = each.value.name
+  resource_group_name = var.resource_group_name
+  location            = var.location
+
+  # The allocation method must be "Static" to use the "StandardV2" SKU.
+  # Ref: https://learn.microsoft.com/en-us/azure/virtual-network/ip-services/public-ip-addresses#sku
+  allocation_method = "Static"
+
+  # The SKU must match the NAT gateway SKU name.
+  sku = "StandardV2"
+
+  tags = var.tags
+}
+
 resource "azurerm_nat_gateway" "this" {
   name                = var.gateway_name
   resource_group_name = var.resource_group_name
   location            = var.location
-  sku_name            = "StandardV2" # Required to create a diagnostic setting.
+
+  # The "StandardV2" SKU is required to create a diagnostic setting.
+  sku_name = "StandardV2"
 
   tags = var.tags
 }
 
 resource "azurerm_nat_gateway_public_ip_association" "this" {
-  count = length(var.public_ip_address_ids)
+  for_each = azurerm_public_ip.this
 
   nat_gateway_id       = azurerm_nat_gateway.this.id
-  public_ip_address_id = var.public_ip_address_ids[count.index]
-}
-
-resource "azurerm_nat_gateway_public_ip_prefix_association" "this" {
-  count = length(var.public_ip_prefix_ids)
-
-  nat_gateway_id      = azurerm_nat_gateway.this.id
-  public_ip_prefix_id = var.public_ip_prefix_ids[count.index]
+  public_ip_address_id = each.value.id
 }
 
 # Don't create "azurerm_subnet_nat_gateway_association" resources in this module.

--- a/main.tf
+++ b/main.tf
@@ -2,9 +2,7 @@ resource "azurerm_nat_gateway" "this" {
   name                = var.gateway_name
   resource_group_name = var.resource_group_name
   location            = var.location
-
-  # The "StandardV2" SKU is required to create a diagnostic setting.
-  sku_name = "StandardV2"
+  sku_name            = "StandardV2" # Required to create a diagnostic setting.
 
   tags = var.tags
 }
@@ -15,14 +13,9 @@ resource "azurerm_public_ip" "this" {
   name                = each.value.name
   resource_group_name = var.resource_group_name
   location            = var.location
+  sku                 = "StandardV2" # Required when NAT gateway SKU name is "StandardV2".
+  allocation_method   = "Static"     # Required when SKU is "StandardV2".
   ip_version          = each.value.ip_version
-
-  # The SKU must match the NAT gateway SKU name.
-  sku = "StandardV2"
-
-  # The allocation method must be "Static" to use the "StandardV2" SKU.
-  # Ref: https://learn.microsoft.com/en-us/azure/virtual-network/ip-services/public-ip-addresses#sku
-  allocation_method = "Static"
 
   tags = var.tags
 }
@@ -40,11 +33,9 @@ resource "azurerm_public_ip_prefix" "this" {
   name                = each.value.name
   resource_group_name = var.resource_group_name
   location            = var.location
+  sku                 = "StandardV2" # Required when NAT gateway SKU name is "StandardV2".
   ip_version          = each.value.ip_version
   prefix_length       = each.value.prefix_length
-
-  # The SKU must match the NAT gateway SKU name.
-  sku = "StandardV2"
 
   tags = var.tags
 }

--- a/main.tf
+++ b/main.tf
@@ -43,6 +43,8 @@ resource "azurerm_public_ip_prefix" "this" {
   # The SKU must match the NAT gateway SKU name.
   sku = "StandardV2"
 
+  prefix_length = each.value.prefix_length
+
   tags = var.tags
 }
 

--- a/main.tf
+++ b/main.tf
@@ -15,13 +15,14 @@ resource "azurerm_public_ip" "this" {
   name                = each.value.name
   resource_group_name = var.resource_group_name
   location            = var.location
+  ip_version          = each.value.ip_version
+
+  # The SKU must match the NAT gateway SKU name.
+  sku = "StandardV2"
 
   # The allocation method must be "Static" to use the "StandardV2" SKU.
   # Ref: https://learn.microsoft.com/en-us/azure/virtual-network/ip-services/public-ip-addresses#sku
   allocation_method = "Static"
-
-  # The SKU must match the NAT gateway SKU name.
-  sku = "StandardV2"
 
   tags = var.tags
 }
@@ -39,11 +40,11 @@ resource "azurerm_public_ip_prefix" "this" {
   name                = each.value.name
   resource_group_name = var.resource_group_name
   location            = var.location
+  ip_version          = each.value.ip_version
+  prefix_length       = each.value.prefix_length
 
   # The SKU must match the NAT gateway SKU name.
   sku = "StandardV2"
-
-  prefix_length = each.value.prefix_length
 
   tags = var.tags
 }

--- a/main.tf
+++ b/main.tf
@@ -10,7 +10,7 @@ resource "azurerm_nat_gateway" "this" {
 }
 
 resource "azurerm_public_ip" "this" {
-  for_each = var.public_ips
+  for_each = var.public_ip_addresses
 
   name                = each.value.name
   resource_group_name = var.resource_group_name

--- a/main.tf
+++ b/main.tf
@@ -1,3 +1,14 @@
+resource "azurerm_nat_gateway" "this" {
+  name                = var.gateway_name
+  resource_group_name = var.resource_group_name
+  location            = var.location
+
+  # The "StandardV2" SKU is required to create a diagnostic setting.
+  sku_name = "StandardV2"
+
+  tags = var.tags
+}
+
 resource "azurerm_public_ip" "this" {
   for_each = var.public_ips
 
@@ -15,22 +26,31 @@ resource "azurerm_public_ip" "this" {
   tags = var.tags
 }
 
-resource "azurerm_nat_gateway" "this" {
-  name                = var.gateway_name
-  resource_group_name = var.resource_group_name
-  location            = var.location
-
-  # The "StandardV2" SKU is required to create a diagnostic setting.
-  sku_name = "StandardV2"
-
-  tags = var.tags
-}
-
 resource "azurerm_nat_gateway_public_ip_association" "this" {
   for_each = azurerm_public_ip.this
 
   nat_gateway_id       = azurerm_nat_gateway.this.id
   public_ip_address_id = each.value.id
+}
+
+resource "azurerm_public_ip_prefix" "this" {
+  for_each = var.public_ip_prefixes
+
+  name                = each.value.name
+  resource_group_name = var.resource_group_name
+  location            = var.location
+
+  # The SKU must match the NAT gateway SKU name.
+  sku = "StandardV2"
+
+  tags = var.tags
+}
+
+resource "azurerm_nat_gateway_public_ip_prefix_association" "this" {
+  for_each = azurerm_public_ip_prefix.this
+
+  nat_gateway_id      = azurerm_nat_gateway.this.id
+  public_ip_prefix_id = each.value.id
 }
 
 # Don't create "azurerm_subnet_nat_gateway_association" resources in this module.

--- a/variables.tf
+++ b/variables.tf
@@ -28,7 +28,8 @@ variable "public_ip_addresses" {
   default = {
     # Default to same Public IP address configuration as in Azure Portal.
     "default" = {
-      name = "nat-pip"
+      name       = "nat-pip"
+      ip_version = optional(string, "IPv4")
     }
   }
 }
@@ -37,6 +38,7 @@ variable "public_ip_prefixes" {
   description = "A map of Public IP prefixes to create and associate with this NAT gateway."
   type = map(object({
     name          = string
+    ip_version    = optional(string, "IPv4")
     prefix_length = optional(number, 28)
   }))
   nullable = false

--- a/variables.tf
+++ b/variables.tf
@@ -36,7 +36,8 @@ variable "public_ip_addresses" {
 variable "public_ip_prefixes" {
   description = "A map of Public IP prefixes to create and associate with this NAT gateway."
   type = map(object({
-    name = string
+    name          = string
+    prefix_length = optional(number, 28)
   }))
   nullable = false
   default  = {}

--- a/variables.tf
+++ b/variables.tf
@@ -22,14 +22,14 @@ variable "log_analytics_workspace_id" {
 variable "public_ip_addresses" {
   description = "A map of Public IP addresses to create and associate with this NAT gateway."
   type = map(object({
-    name = string
+    name       = string
+    ip_version = optional(string, "IPv4")
   }))
   nullable = false
   default = {
     # Default to same Public IP address configuration as in Azure Portal.
     "default" = {
-      name       = "nat-pip"
-      ip_version = optional(string, "IPv4")
+      name = "nat-pip"
     }
   }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -19,7 +19,7 @@ variable "log_analytics_workspace_id" {
   nullable    = false
 }
 
-variable "public_ips" {
+variable "public_ip_addresses" {
   description = "A map of Public IP addresses to create and associate with this NAT gateway."
   type = map(object({
     name = string

--- a/variables.tf
+++ b/variables.tf
@@ -33,6 +33,15 @@ variable "public_ips" {
   }
 }
 
+variable "public_ip_prefixes" {
+  description = "A map of Public IP prefixes to create and associate with this NAT gateway."
+  type = map(object({
+    name = string
+  }))
+  nullable = false
+  default  = {}
+}
+
 variable "diagnostic_setting_name" {
   description = "The name of this diagnostic setting."
   type        = string

--- a/variables.tf
+++ b/variables.tf
@@ -19,16 +19,18 @@ variable "log_analytics_workspace_id" {
   nullable    = false
 }
 
-variable "public_ip_address_ids" {
-  description = "A list of IDs of Public IP addresses to associate with this NAT gateway."
-  type        = list(string)
-  default     = []
-}
-
-variable "public_ip_prefix_ids" {
-  description = "A list of IDs of Public IP prefixes to associate with this NAT gateway."
-  type        = list(string)
-  default     = []
+variable "public_ips" {
+  description = "A map of Public IP addresses to create and associate with this NAT gateway."
+  type = map(object({
+    name = string
+  }))
+  nullable = false
+  default = {
+    # Default to same Public IP address configuration as in Azure Portal.
+    "default" = {
+      name = "nat-pip"
+    }
+  }
 }
 
 variable "diagnostic_setting_name" {


### PR DESCRIPTION
Integrate the creation of Public IP resources into this module. The rationale is in order to associate a Public IP with a NAT gateway, that the Public IP address **must** use a static allocation method and an **identical** SKU as the NAT gateway. Instead of expecting consumers of this module to know this, automatically create compliant resources.

BREAKING CHANGE: remove variables `public_ip_address_ids` and `public_ip_prefix_ids`. Create Public IP resources using the `public_ip_addresses` and `public_ip_prefixes` variables instead.