### PR TITLE
feat: add variable `sku_name`

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Terraform module which creates Azure NAT Gateway resources.
 
 - Creates a StandardV2 tier NAT gateway in the specified resource group.
 - Creates and associates a Public IP address with the NAT gateway by default.
-- Flow logs sent to given Log Analytics workspace by default.
+- Flow logs sent to given Log Analytics workspace by default (StandardV2 tier only).
 
 ## Prerequisites
 

--- a/main.tf
+++ b/main.tf
@@ -2,7 +2,7 @@ resource "azurerm_nat_gateway" "this" {
   name                = var.gateway_name
   resource_group_name = var.resource_group_name
   location            = var.location
-  sku_name            = "StandardV2" # Required to create a diagnostic setting.
+  sku_name            = var.sku_name
 
   tags = var.tags
 }
@@ -13,8 +13,8 @@ resource "azurerm_public_ip" "this" {
   name                = each.value.name
   resource_group_name = var.resource_group_name
   location            = var.location
-  sku                 = "StandardV2" # Required when NAT gateway SKU name is "StandardV2".
-  allocation_method   = "Static"     # Required when SKU is "StandardV2".
+  sku                 = var.sku_name # Must match NAT gateway SKU name.
+  allocation_method   = "Static"     # Required when SKU is "StandardV2" or "Standard".
   ip_version          = each.value.ip_version
 
   tags = var.tags
@@ -33,7 +33,7 @@ resource "azurerm_public_ip_prefix" "this" {
   name                = each.value.name
   resource_group_name = var.resource_group_name
   location            = var.location
-  sku                 = "StandardV2" # Required when NAT gateway SKU name is "StandardV2".
+  sku                 = var.sku_name # Must match NAT gateway SKU name.
   ip_version          = each.value.ip_version
   prefix_length       = each.value.prefix_length
 
@@ -55,6 +55,8 @@ resource "azurerm_nat_gateway_public_ip_prefix_association" "this" {
 # a subnet is associated with a NAT gateway during subnet creation.
 
 resource "azurerm_monitor_diagnostic_setting" "this" {
+  count = var.sku_name == "StandardV2" ? 1 : 0
+
   name                           = var.diagnostic_setting_name
   target_resource_id             = azurerm_nat_gateway.this.id
   log_analytics_workspace_id     = var.log_analytics_workspace_id
@@ -73,6 +75,13 @@ resource "azurerm_monitor_diagnostic_setting" "this" {
 
     content {
       category = enabled_metric.value
+    }
+  }
+
+  lifecycle {
+    precondition {
+      condition     = var.log_analytics_workspace_id != null
+      error_message = "Log Analytics workspace ID must be set when SKU name is \"StandardV2\"."
     }
   }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -13,10 +13,22 @@ variable "location" {
   type        = string
 }
 
-variable "log_analytics_workspace_id" {
-  description = "The ID of the Log Analytics workspace to send diagnostics to."
+variable "sku_name" {
+  description = "The SKU name for this NAT gateway. Value must be \"StandardV2\" or \"Standard\"."
   type        = string
   nullable    = false
+  default     = "StandardV2"
+
+  validation {
+    condition     = contains(["StandardV2", "Standard"], var.sku_name)
+    error_message = "SKU name must be \"StandardV2\" or \"Standard\"."
+  }
+}
+
+variable "log_analytics_workspace_id" {
+  description = "The ID of the Log Analytics workspace to send diagnostics to. Required if SKU name is \"StandardV2\"."
+  type        = string
+  nullable    = true
 }
 
 variable "public_ip_addresses" {


### PR DESCRIPTION
Add a variable to allow specifying the SKU name for the NAT gateway. Allows consumers of v2 to keep using the `Standard` SKU in v3.