### PR TITLE
refactor: explicitly set `log_analytics_destination_type` to `null`

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -60,7 +60,7 @@ resource "azurerm_monitor_diagnostic_setting" "this" {
   name                           = var.diagnostic_setting_name
   target_resource_id             = azurerm_nat_gateway.this.id
   log_analytics_workspace_id     = var.log_analytics_workspace_id
-  log_analytics_destination_type = "Dedicated"
+  log_analytics_destination_type = null
 
   dynamic "enabled_log" {
     for_each = toset(var.diagnostic_setting_enabled_log_categories)


### PR DESCRIPTION
Azure seems to remove the `log_analytics_destination_type` argument server-side, repeatedly resulting in the following output when running `terraform plan` on a NAT gateway managed using this module:

```terraform
Terraform used the selected providers to generate the following execution
plan. Resource actions are indicated with the following symbols:
  ~ update in-place

Terraform will perform the following actions:

  # module.networking.module.nat.azurerm_monitor_diagnostic_setting.this[0] will be updated in-place
  ~ resource "azurerm_monitor_diagnostic_setting" "this" {
        id                             = "/subscriptions/<SUBSCRIPTION_ID>/resourceGroups/<RESOURCE_GROUP_NAME>/providers/Microsoft.Network/natGateways/<NAT_GATEWAY_NAME>|flow-logs"
      + log_analytics_destination_type = "Dedicated"
        name                           = "flow-logs"
        # (4 unchanged attributes hidden)

        # (2 unchanged blocks hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.
```

Explicitly set to `null` to reflect this behaviour in Terraform.